### PR TITLE
Stop requiring slug on page editing

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -31,10 +31,7 @@ collections:
     label: "Pages"
     folder: "content/pages"
     create: true
-    slug: "{{slug}}"
     fields:
       - {label: "Template", name: "template", widget: "hidden", default: "page"}
       - {label: "Title", name: "title", widget: "string"}
-      - {label: "Slug", name: "slug", widget: "string"}
-      - {label: "Draft", name: "draft", widget: "boolean", default: true}
       - {label: "Body", name: "body", widget: "markdown"}


### PR DESCRIPTION
Inputting a slug manually (which is required by the netlify CMS UI)
breaks the pathing logic of Gatsby. This way should work better, I
... think.
